### PR TITLE
don't try to repeatedly convert dst to shell item

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license='MIT',
     url='http://github.com/frmdstryr/pywinutils',
     description="Copy move and delete files using the built in Window's progress dialog",
-    long_description=open("README.MD").read(),
+    long_description=open("README.md").read(),
     py_modules=['winutils'],
     requires=['pywin32'],
     install_requires=['pywin32 >= 218'],

--- a/winutils.py
+++ b/winutils.py
@@ -20,18 +20,16 @@ def _file_operation(src,dst=None,operation='copy',flags=shellcon.FOF_NOCONFIRMAT
     if not isinstance(src,(tuple,list)):
         src = (src,)
 
+    if dst is not None:
+        # Set the destination folder
+        dst = shell.SHCreateItemFromParsingName(dst,None,shell.IID_IShellItem)
+
     for f in src:
         item = shell.SHCreateItemFromParsingName(f,None,shell.IID_IShellItem)
         op = operation.strip().lower()
         if op=='copy':
-            # Set the destionation folder
-            dst = shell.SHCreateItemFromParsingName(dst,None,shell.IID_IShellItem)
-
             pfo.CopyItem(item,dst) # Schedule an operation to be performed
         elif op=='move':
-            # Set the destionation folder
-            dst = shell.SHCreateItemFromParsingName(dst,None,shell.IID_IShellItem)
-            
             pfo.MoveItem(item,dst)
         elif op=='delete':
             pfo.DeleteItem(item)


### PR DESCRIPTION
If you pass more than one src file, then on the second loop iteration, it will
try to build a new IShellItem out of the existing IShellItem.  Only convert
dst to an IShellItem once.